### PR TITLE
Use hash instead of openstruct

### DIFF
--- a/lib/kleisli/run.rb
+++ b/lib/kleisli/run.rb
@@ -1,5 +1,4 @@
 require "kleisli/run/version"
-require 'ostruct'
 
 module Kleisli
 
@@ -17,7 +16,7 @@ module Kleisli
     attr_reader :start
 
     def initialize(block_binding)
-      @struct = OpenStruct.new
+      @hash = {}
       @stopped = false
       @start = false
       @o_self = block_binding.eval('self')
@@ -32,11 +31,11 @@ module Kleisli
     end
 
     def set_value(k, v)
-      @struct.send("#{k}=".to_sym, v)
+      @hash[k] = v
     end
 
     def get_value(k)
-      @struct.send(k)
+      @hash[k]
     end
 
     def method_missing(m, *args)
@@ -51,22 +50,6 @@ module Kleisli
       else
         set_value(m, args.first)
       end
-    end
-  end
-
-  class HashRunner < Runner
-
-    def initialize(block_binding)
-      super(block_binding)
-      @hash = {}
-    end
-
-    def set_value(k, v)
-      @hash[k] = v
-    end
-
-    def get_value(k)
-      @hash[k]
     end
   end
 

--- a/lib/kleisli/run/version.rb
+++ b/lib/kleisli/run/version.rb
@@ -1,5 +1,5 @@
 module Kleisli
   module Run
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end

--- a/test/kleisli/run_test.rb
+++ b/test/kleisli/run_test.rb
@@ -97,35 +97,4 @@ class RunTest < Minitest::Test
     end
     assert(Success(10), s)
   end
-
-  def test_perf_hash_vs_ostruct
-    iterations = 100000
-    ht = Benchmark.measure do
-      iterations.times do
-        Kleisli.run(Kleisli::HashRunner) do
-          a = Success(1)
-          b = Success(2)
-          c = Success(3)
-          d from: Success(-> x, y, z { x + y + z }) * a * b * c
-          e = sums(d, 4)
-        end
-      end
-    end
-
-    ost = Benchmark.measure do
-      iterations.times do
-        Kleisli.run do
-          a = Success(1)
-          b = Success(2)
-          c = Success(3)
-          d from: Success(-> x, y, z { x + y + z }) * a * b * c
-          e = sums(d, 4)
-        end
-      end
-    end
-
-    puts ht
-    puts ost
-  end
-
 end

--- a/test/kleisli/run_test.rb
+++ b/test/kleisli/run_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'benchmark'
 
 class RunTest < Minitest::Test
 

--- a/test/kleisli/run_test.rb
+++ b/test/kleisli/run_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'benchmark'
 
 class RunTest < Minitest::Test
 
@@ -95,6 +96,36 @@ class RunTest < Minitest::Test
       e = sums(d, 4)
     end
     assert(Success(10), s)
+  end
+
+  def test_perf_hash_vs_ostruct
+    iterations = 100000
+    ht = Benchmark.measure do
+      iterations.times do
+        Kleisli.run(Kleisli::HashRunner) do
+          a = Success(1)
+          b = Success(2)
+          c = Success(3)
+          d from: Success(-> x, y, z { x + y + z }) * a * b * c
+          e = sums(d, 4)
+        end
+      end
+    end
+
+    ost = Benchmark.measure do
+      iterations.times do
+        Kleisli.run do
+          a = Success(1)
+          b = Success(2)
+          c = Success(3)
+          d from: Success(-> x, y, z { x + y + z }) * a * b * c
+          e = sums(d, 4)
+        end
+      end
+    end
+
+    puts ht
+    puts ost
   end
 
 end


### PR DESCRIPTION
Thanks to @waterline for the suggestion

Performance comparison over 100k iterations through a short block (hash on top, openstruct on bottom)

4.690000   0.090000   4.780000 (  4.807243)
  7.560000   0.120000   7.680000 (  7.903846)
